### PR TITLE
Revert min. R version to 3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Encoding: UTF-8
 URL: https://github.com/worldhealthorganization/anthro
 BugReports: https://github.com/worldhealthorganization/anthro/issues
 ByteCompile: true
-Depends: R (>= 3.5)
+Depends: R (>= 3.2)
 Imports: 
     survey
 Suggests: 


### PR DESCRIPTION
Even though survey requires 3.5, the z-scores should still work
with 3.2 as we have not changed the compression algorithm to version
3. So folks on R < 3.5 could use an older version of survey together with {anthro} to compute z-scores.