### PR TITLE
Adjust lenhei/weight prior to z-score computation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # anthro (development version)
 
+## Method
+
+* Prior to z-score computation, _length/height_ and _weight_ are set to `NA`
+  if they exceed the plausible range of values.
+  For _length/height_ this is `35cm to 140cm` and for _weight_ it is
+  `0.5kg to 40kg`.
+  The adjusted values are shown in the resulting data frame under columns
+  `clenhei` and `cweight` respectively.
+
 ## Performance
 
 * For inputs with `cluster/strata = NULL` and `sw = NULL or 1` a faster

--- a/R/z-score-helper.R
+++ b/R/z-score-helper.R
@@ -145,7 +145,7 @@ anthro_zscore_adjusted <-
     )
 
     # we only compute zscores for children age < 60 months
-    # the age in months is unrouned
+    # the age in months is unrounded
     valid_age <- age_in_months < 60
 
     # at last we set certain zscores to NA

--- a/R/z-score-weight-for-lenhei.R
+++ b/R/z-score-weight-for-lenhei.R
@@ -32,10 +32,6 @@ anthro_zscore_weight_for_lenhei <-
     # then we have everything to compute the zscores
     n <- length(lenhei)
 
-    # clean weight/lenhei
-    weight[weight < 0.9 | weight > 58.0] <- NA_real_
-    lenhei[lenhei < 38.0 | lenhei > 150.0] <- NA_real_
-
     # we also need to interpolate lenhei under certain coniditions
     low_lenhei <- trunc(lenhei * 10) / 10
     upp_lenhei <- trunc(lenhei * 10 + 1) / 10

--- a/R/z-score.R
+++ b/R/z-score.R
@@ -136,6 +136,8 @@
 #' WHO Multicentre Growth Reference Study Group (2007). WHO Child Growth Standards: Head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age: Methods and development.
 #' Geneva: World Health Organization; pp 217. (web site: http://www.who.int/childgrowth/publications/en/ )
 #'
+#' World Health Organization. (2019). Recommendations for data collection, analysis and reporting on anthropometric indicators in children under 5 years old.
+#'
 #' @examples
 #' # you can either use the function to compute zscores for specific values
 #' anthro_zscores(sex = "f", age = 10, is_age_in_month = TRUE, weight = 10)
@@ -214,6 +216,12 @@ anthro_zscores <- function(sex,
   subskin <- rep_len(subskin, length.out = max_len)
   oedema <- rep_len(oedema, length.out = max_len)
 
+  # clean weight/height
+  clenhei <- lenhei
+  clenhei[clenhei < 35.0 | clenhei > 140.0] <- NA_real_
+  cweight <- weight
+  cweight[cweight < 0.5 | cweight > 40.0] <- NA_real_
+
   # clean sex
   csex <- standardize_sex_var(sex)
 
@@ -235,11 +243,12 @@ anthro_zscores <- function(sex,
     age_in_months < 9
   cmeasure[measure_implausible] <- NA_character_
 
-  clenhei <- adjust_lenhei(age_in_days, cmeasure, lenhei)
+  clenhei <- adjust_lenhei(age_in_days, cmeasure, clenhei)
 
-  cbmi <- weight / ((clenhei / 100)^2)
+  cbmi <- cweight / ((clenhei / 100)^2)
   cbind(
     clenhei,
+    cweight,
     cbmi,
     cmeasure,
     csex,
@@ -250,14 +259,14 @@ anthro_zscores <- function(sex,
       sex = csex
     ),
     anthro_zscore_weight_for_age(
-      weight = weight,
+      weight = cweight,
       age_in_days = age_in_days,
       age_in_months = age_in_months,
       sex = csex,
       oedema = oedema
     ),
     anthro_zscore_weight_for_lenhei(
-      weight = weight,
+      weight = cweight,
       lenhei = clenhei,
       lenhei_unit = cmeasure,
       age_in_days = age_in_days,

--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ anthro_zscores(
   weight = c(18, 15, 10, 15),
   lenhei = c(120, 80, 100, 100)
 )
-#>   clenhei    cbmi cmeasure csex  zlen flen  zwei fwei  zwfl fwfl  zbmi fbmi zhc
-#> 1     120 12.5000     <NA>    1  7.31    1  2.20    0 -2.39    0 -3.01    0  NA
-#> 2      80 23.4375     <NA>    2 -3.50    0  0.95    0  4.13    0  4.66    0  NA
-#> 3     100 10.0000     <NA>    1  1.62    0 -2.76    0 -5.19    1 -5.61    1  NA
-#> 4     100 15.0000     <NA>    1  1.70    0  0.69    0 -0.29    0 -0.58    0  NA
-#>   fhc zac fac zts fts zss fss
-#> 1  NA  NA  NA  NA  NA  NA  NA
-#> 2  NA  NA  NA  NA  NA  NA  NA
-#> 3  NA  NA  NA  NA  NA  NA  NA
-#> 4  NA  NA  NA  NA  NA  NA  NA
+#>   clenhei cweight    cbmi cmeasure csex  zlen flen  zwei fwei  zwfl fwfl  zbmi
+#> 1     120      18 12.5000     <NA>    1  7.31    1  2.20    0 -2.39    0 -3.01
+#> 2      80      15 23.4375     <NA>    2 -3.50    0  0.95    0  4.13    0  4.66
+#> 3     100      10 10.0000     <NA>    1  1.62    0 -2.76    0 -5.19    1 -5.61
+#> 4     100      15 15.0000     <NA>    1  1.70    0  0.69    0 -0.29    0 -0.58
+#>   fbmi zhc fhc zac fac zts fts zss fss
+#> 1    0  NA  NA  NA  NA  NA  NA  NA  NA
+#> 2    0  NA  NA  NA  NA  NA  NA  NA  NA
+#> 3    1  NA  NA  NA  NA  NA  NA  NA  NA
+#> 4    0  NA  NA  NA  NA  NA  NA  NA  NA
 ```
 
 The returned value is a `data.frame` that can further be processed or

--- a/man/anthro_zscores.Rd
+++ b/man/anthro_zscores.Rd
@@ -182,4 +182,6 @@ Geneva: World Health Organization; pp 312. (web site: http://www.who.int/childgr
 
 WHO Multicentre Growth Reference Study Group (2007). WHO Child Growth Standards: Head circumference-for-age, arm circumference-for-age, triceps skinfold-for-age and subscapular skinfold-for-age: Methods and development.
 Geneva: World Health Organization; pp 217. (web site: http://www.who.int/childgrowth/publications/en/ )
+
+World Health Organization. (2019). Recommendations for data collection, analysis and reporting on anthropometric indicators in children under 5 years old.
 }

--- a/tests/testthat/test-zscores.R
+++ b/tests/testthat/test-zscores.R
@@ -203,8 +203,8 @@ test_that("zcores are only computed for children younger to 60 months", {
     headc = 5,
     measure = "h"
   )
-  expect_true(all(is.na(res[2:3, -1:-4])))
-  expect_false(all(is.na(res[1, -1:-4])))
+  expect_true(all(is.na(res[2:3, -1:-5])))
+  expect_false(all(is.na(res[1, -1:-5])))
 })
 
 test_that("height measurements are used for age 24 months", {
@@ -240,4 +240,42 @@ test_that("clenhei takes the measure argument into account correctly", {
   )
   expect_equal(res$clenhei, c(77.5, 77.5))
   expect_equal(res$zlen, c(-2.55, -2.55))
+})
+
+test_that("weight is set to NA if it is out of bounds", {
+  res <- anthro_zscores(
+    age = 100,
+    sex = 1,
+    lenhei = 100,
+    weight = c(0.4, 41)
+  )
+  expect_true(all(is.na(res$cweight)))
+  expect_true(all(is.na(res$cbmi)))
+  expect_false(all(is.na(res$zlen)))
+  expect_false(all(is.na(res$flen)))
+  expect_true(all(is.na(res$zwfl)))
+  expect_true(all(is.na(res$fwfl)))
+  expect_true(all(is.na(res$zbmi)))
+  expect_true(all(is.na(res$fbmi)))
+  expect_true(all(is.na(res$zwei)))
+  expect_true(all(is.na(res$fwei)))
+})
+
+test_that("lenhei is set to NA if it is out of bounds", {
+  res <- anthro_zscores(
+    age = 100,
+    sex = 1,
+    lenhei = c(34, 141),
+    weight = 40
+  )
+  expect_true(all(is.na(res$clenhei)))
+  expect_true(all(is.na(res$cbmi)))
+  expect_true(all(is.na(res$zlen)))
+  expect_true(all(is.na(res$flen)))
+  expect_true(all(is.na(res$zwfl)))
+  expect_true(all(is.na(res$fwfl)))
+  expect_true(all(is.na(res$zbmi)))
+  expect_true(all(is.na(res$fbmi)))
+  expect_false(all(is.na(res$zwei)))
+  expect_false(all(is.na(res$fwei)))
 })


### PR DESCRIPTION
Prior to z-score computation, _length/height_ and _weight_ are set to `NA` if they exceed the plausible range of values.
For _length/height_ this is `35cm to 140cm` and for _weight_ it is `0.5kg to 40kg`.
The adjusted values are shown in the resulting data frame under columns `clenhei` and `cweight` respectively.